### PR TITLE
build: use CircleCI cimg/node images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,11 @@ orbs:
 jobs:
   test-linux-14:
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14.21
     <<: *steps-test
   test-linux-16:
     docker:
-      - image: circleci/node:16
+      - image: cimg/node:16.19
     <<: *steps-test
 workflows:
   test_and_release:


### PR DESCRIPTION
Older images are deprecated.