### PR TITLE
chore: resolve dependabot security alerts

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -201,12 +201,12 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.12
-  resolution: "brace-expansion@npm:1.1.12"
+  version: 1.1.13
+  resolution: "brace-expansion@npm:1.1.13"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/975fecac2bb7758c062c20d0b3b6288c7cc895219ee25f0a64a9de662dbac981ff0b6e89909c3897c1f84fa353113a721923afdec5f8b2350255b097f12b1f73
+  checksum: 10c0/384c61bb329b6adfdcc0cbbdd108dc19fb5f3e84ae15a02a74f94c6c791b5a9b035aae73b2a51929a8a478e2f0f212a771eb6a8b5b514cccfb8d0c9f2ce8cbd8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Safe-only sweep of open Dependabot security alerts. Lockfile-only — no `package.json` range changes, no `resolutions` entries.

| Package | Strategy | Version change |
| --- | --- | --- |
| `brace-expansion` | `yarn up -R` (transitive, within existing `^1.1.7` range via `minimatch`) | `1.1.12` → `1.1.13` |

Addresses [GHSA-q7cg-6p46-vvmq](https://github.com/advisories/GHSA-q7cg-6p46-vvmq) (ReDoS, medium).

### Flagged (not changed)

None.

### Verification

- `yarn install --immutable` passes
- `yarn npm audit --all --recursive --no-deprecations` → no audit suggestions
- `npmMinimalAgeGate: 10080` respected (`brace-expansion@1.1.13` published 2026-03-27)
- Peer-dep warnings for `eslint`/`typescript` are pre-existing (they're intentionally peers of this config package)
